### PR TITLE
Use the MIT license instead of a custom one

### DIFF
--- a/sh_cami.lua
+++ b/sh_cami.lua
@@ -1,5 +1,7 @@
 --[[
 CAMI - Common Admin Mod Interface.
+Copyright 2019 CAMI Contributors
+
 Makes admin mods intercompatible and provides an abstract privilege interface
 for third party addons.
 
@@ -39,6 +41,12 @@ Structures:
             Function that decides whether a player can execute this privilege,
             optionally on another player (target).
     }
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]]
 
 -- Version number in YearMonthDay format.


### PR DESCRIPTION
Using a custom source code license is confusing and unnecessary, especially if the code itself doesn't specify what the license is.

The MIT license is the closest OSC license to the currently specified one.