### PR TITLE
Add CAMI_Source to CAMI_USERGROUP, set in CAMI.RegisterUsergroup()

### DIFF
--- a/lua/autorun/sh_cami.lua
+++ b/lua/autorun/sh_cami.lua
@@ -28,7 +28,7 @@ CAMI.Version = version
 --- defines the charactaristics of a usergroup
 --- @field Name string @The name of the usergroup
 --- @field Inherits string @The name of the usergroup this usergroup inherits from
---- @field CAMI_Source string @The source specified by the admin mod which registered this usergroup (converted to a string)
+--- @field CAMI_Source string @The source specified by the admin mod which registered this usergroup (if any, converted to a string)
 
 --- @class CAMI_PRIVILEGE
 --- defines the charactaristics of a privilege
@@ -81,7 +81,9 @@ local privileges = CAMI.GetPrivileges and CAMI.GetPrivileges() or {}
 --- @param source any @Identifier for your own admin mod. Can be anything.
 --- @return CAMI_USERGROUP @The usergroup given as an argument
 function CAMI.RegisterUsergroup(usergroup, source)
-    usergroup.CAMI_Source = tostring(source)
+    if source then 
+        usergroup.CAMI_Source = tostring(source)
+    end
     usergroups[usergroup.Name] = usergroup
 
     hook.Call("CAMI.OnUsergroupRegistered", nil, usergroup, source)

--- a/lua/autorun/sh_cami.lua
+++ b/lua/autorun/sh_cami.lua
@@ -81,7 +81,7 @@ local privileges = CAMI.GetPrivileges and CAMI.GetPrivileges() or {}
 --- @param source any @Identifier for your own admin mod. Can be anything.
 --- @return CAMI_USERGROUP @The usergroup given as an argument
 function CAMI.RegisterUsergroup(usergroup, source)
-    if source then 
+    if source then
         usergroup.CAMI_Source = tostring(source)
     end
     usergroups[usergroup.Name] = usergroup

--- a/lua/autorun/sh_cami.lua
+++ b/lua/autorun/sh_cami.lua
@@ -28,7 +28,7 @@ CAMI.Version = version
 --- defines the charactaristics of a usergroup
 --- @field Name string @The name of the usergroup
 --- @field Inherits string @The name of the usergroup this usergroup inherits from
---- @field CAMI_Source any @The source specified by the admin mod which registered this usergroup (can be anything)
+--- @field CAMI_Source string @The source specified by the admin mod which registered this usergroup (converted to a string)
 
 --- @class CAMI_PRIVILEGE
 --- defines the charactaristics of a privilege
@@ -81,7 +81,7 @@ local privileges = CAMI.GetPrivileges and CAMI.GetPrivileges() or {}
 --- @param source any @Identifier for your own admin mod. Can be anything.
 --- @return CAMI_USERGROUP @The usergroup given as an argument
 function CAMI.RegisterUsergroup(usergroup, source)
-    usergroup.CAMI_Source = source
+    usergroup.CAMI_Source = tostring(source)
     usergroups[usergroup.Name] = usergroup
 
     hook.Call("CAMI.OnUsergroupRegistered", nil, usergroup, source)

--- a/lua/autorun/sh_cami.lua
+++ b/lua/autorun/sh_cami.lua
@@ -16,7 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ]]
 
 -- Version number in YearMonthDay format.
-local version = 20201130
+local version = 20211019
 
 if CAMI and CAMI.Version >= version then return end
 
@@ -28,6 +28,7 @@ CAMI.Version = version
 --- defines the charactaristics of a usergroup
 --- @field Name string @The name of the usergroup
 --- @field Inherits string @The name of the usergroup this usergroup inherits from
+--- @field CAMI_Source any @The source specified by the admin mod which registered this usergroup (can be anything)
 
 --- @class CAMI_PRIVILEGE
 --- defines the charactaristics of a privilege
@@ -52,15 +53,18 @@ end
 local usergroups = CAMI.GetUsergroups and CAMI.GetUsergroups() or {
     user = {
         Name = "user",
-        Inherits = "user"
+        Inherits = "user",
+        CAMI_Source = "Garry's Mod",
     },
     admin = {
         Name = "admin",
-        Inherits = "user"
+        Inherits = "user",
+        CAMI_Source = "Garry's Mod",
     },
     superadmin = {
         Name = "superadmin",
-        Inherits = "admin"
+        Inherits = "admin",
+        CAMI_Source = "Garry's Mod",
     }
 }
 
@@ -77,6 +81,7 @@ local privileges = CAMI.GetPrivileges and CAMI.GetPrivileges() or {}
 --- @param source any @Identifier for your own admin mod. Can be anything.
 --- @return CAMI_USERGROUP @The usergroup given as an argument
 function CAMI.RegisterUsergroup(usergroup, source)
+    usergroup.CAMI_Source = source
     usergroups[usergroup.Name] = usergroup
 
     hook.Call("CAMI.OnUsergroupRegistered", nil, usergroup, source)


### PR DESCRIPTION
This PR aims to add the source of a usergroup registered with `CAMI.RegisterUsergroup()` in the `CAMI_USERGROUP` structure.
This would allow admin mods (and other addons if they wish) to know what created the usergroup.

The reasoning behind the name `CAMI_Source` is just to minimize the possibility of a conflict with another addon. Feel free to edit if wanted.

I did figure out a potential issue: the `source` argument of the `RegisterUsergroup()` function is specified as `any`, meaning an addon could technically put a whole table in there. While this wouldn't necessarily be an issue, anyone networking the usergroups table using `net.WriteTable()` would have a nasty surprise waiting for them once any addon updates CAMI.

The solution to this was simply to call `tostring()` on the source. This is only for what is stored in the table, in order to avoid breaking any addon, the original source is passed unaffected to the `CAMI.OnUsergroupRegistered()` hook.